### PR TITLE
[FIX] Issue #46

### DIFF
--- a/WebApp/client/src/components/UploadMusic/UploadMusic.js
+++ b/WebApp/client/src/components/UploadMusic/UploadMusic.js
@@ -55,7 +55,10 @@ function UploadMusic () {
                 data.append('musicFile', musicFile)
             }
             NotificationManager.info("Please wait", "You've send the music", 5000);
-            axios.post(`${URL}/uploadMusic`, data, {headers: {"Content-Type": "multipart/form-data"}})
+            axios.post(`${URL}/uploadMusic`, data, {
+                headers: {"Content-Type": "multipart/form-data"},
+                withCredentials : true
+            })
                 .then(() => {
                     NotificationManager.success('You are now free to use what you\'ve uploaded', 'Upload succes', 5000);
                 })

--- a/WebApp/server/controllers/data.js
+++ b/WebApp/server/controllers/data.js
@@ -183,6 +183,11 @@ const uploadMusic = async (request, response) => {
     const userName = 'ChaosArnhug' //request.user ; //DOIT ETRE DYNAMIQUE EN FONCTION DU USER CONNECTE CF token login
 
     try {
+        const userName = await whoIsConnected(request.signedCookies)
+        if (! userName){
+            return response.status(403).send('You have to be connected');
+        }
+
         const sftp = new sftpClient();
 
         sftp.connect(configFtp)


### PR DESCRIPTION
L'utilisateur était hardcodé au lieu de dépendre de qui est connecté.

Maintenant, l'enpoint vérifie qui est connecté et utilise cette personne pour la suite de la requête. Dans le cas contraire, la requête est rejeté.

Rajout de `withcredential: true` de la requête HTTP en front pour envoyé le cookie de session