### PR TITLE
[FIX] ISSUE #54

### DIFF
--- a/.github/workflows/Jest-Testing.yml
+++ b/.github/workflows/Jest-Testing.yml
@@ -26,8 +26,5 @@ jobs:
       - name: Run Jest
         working-directory: 'WebApp/server'
         env: 
-          DB_HOST: ${{ secrets.DB_HOST }}
-          DB_PASSWORD: ${{ secrets.DB_PASSWORD }}
-          DB_USER: ${{ secrets.DB_USER }}
           COOKIE_SECRET : ${{ secrets.COOKIE_SECRET}}
         run: npm test

--- a/WebApp/server/database/database.js
+++ b/WebApp/server/database/database.js
@@ -3,10 +3,10 @@ const mysql = require('mysql2')
 //mysql connexion
 //using DOTENV to avoid sensible data in github repo
 const connexion = mysql.createConnection({
-    host: '78.129.32.10',
-    password: 'Bv87VuDDj|fD',
+    host: process.env.DB_HOST,
+    password: process.env.DB_PASSWORD,
     database: 'ShuffleTunes',
-    user : 'ShuffleTunes'
+    user : process.env.DB_USER
 })
 
 connexion.connect(function(err) {

--- a/WebApp/server/server.js
+++ b/WebApp/server/server.js
@@ -19,7 +19,11 @@ app.use(cors({origin: "http://127.0.0.1:3000", credentials: true}));
 //utiliser le router nodejs
 app.use('/',Route);
 
-//port serveur nodejs
-app.listen(5000, ()=>{console.log("server running on port 5000")})
+if (process.env.NODE_ENV === 'test'){
+    app.listen();
+} else {
+    //port serveur nodejs
+    app.listen(5000, ()=>{console.log("server running on port 5000")})
+}
 
 module.exports = app


### PR DESCRIPTION
Les tests auto backend utilisaient le même port(5000). Cela a pour conséquence de faire rater les tests qui n'arrive pas à accéder au port 5000.

Maintenant, lorqu'on est en environnement de tests, le port n'est plus mis par defaut à 5000 et est attribué automatiquement.

PS : retait credential db + variable d'environnement DB pour les tests auto puisqu'on est sensé la mock